### PR TITLE
fix(config): update config.json permissions

### DIFF
--- a/manifests/files.pp
+++ b/manifests/files.pp
@@ -65,7 +65,7 @@ class lacework::files (
 
   file {"${base_path}/config/config.json":
     ensure    => 'present',
-    mode      => '0660',
+    mode      => '0640',
     owner     => 'root',
     group     => 'root',
     content   => to_json_pretty($params_filtered),

--- a/spec/classes/lacework_spec.rb
+++ b/spec/classes/lacework_spec.rb
@@ -21,7 +21,7 @@ describe 'lacework' do
         it { is_expected.to contain_file('/var/lib/lacework').with_mode('0755') }
         it { is_expected.to contain_file('/var/lib/lacework/config').with_mode('0755') }
         it { is_expected.to contain_file('/var/lib/lacework/config').with_ensure('directory') }
-        it { is_expected.to contain_file('/var/lib/lacework/config/config.json').with_mode('0660') }
+        it { is_expected.to contain_file('/var/lib/lacework/config/config.json').with_mode('0640') }
         it { is_expected.to contain_file(conf_path).with('content' => %r{\"AccessToken\"\: \"no\"}) }
       end
 


### PR DESCRIPTION
Update permissions to use 0640 instead of 0660 to prevent agent restarts